### PR TITLE
Spruce up examples

### DIFF
--- a/adafruit_ssd1327.py
+++ b/adafruit_ssd1327.py
@@ -79,7 +79,6 @@ class SSD1327(displayio.Display):
         if "rotation" in kwargs and kwargs["rotation"] % 180 != 0:
             height = kwargs["width"]
         init_sequence[18] = height - 1  # patch mux ratio
-        print(height)
         super().__init__(
             bus,
             init_sequence,

--- a/examples/ssd1327_gamma.py
+++ b/examples/ssd1327_gamma.py
@@ -6,15 +6,19 @@ import adafruit_ssd1327
 
 displayio.release_displays()
 
-# This pinout works on a Metro and may need to be altered for other boards.
-spi = busio.SPI(board.SCL, board.SDA)
-tft_cs = board.D6
-tft_dc = board.D9
-tft_reset = board.D5
+# Use for I2C
+i2c = board.I2C()
+display_bus = displayio.I2CDisplay(i2c, device_address=0x3D)
 
-display_bus = displayio.FourWire(
-    spi, command=tft_dc, chip_select=tft_cs, reset=tft_reset, baudrate=1000000
-)
+# Use for SPI
+# spi = board.SPI()
+# oled_cs = board.D5
+# oled_dc = board.D6
+# display_bus = displayio.FourWire(
+#    spi, command=oled_dc, chip_select=oled_cs, baudrate=1000000, reset=board.D9
+# )
+
+
 time.sleep(1)
 display = adafruit_ssd1327.SSD1327(display_bus, width=128, height=128)
 

--- a/examples/ssd1327_gamma.py
+++ b/examples/ssd1327_gamma.py
@@ -1,6 +1,5 @@
 import time
 import board
-import busio
 import displayio
 import adafruit_ssd1327
 

--- a/examples/ssd1327_simpletest.py
+++ b/examples/ssd1327_simpletest.py
@@ -1,19 +1,68 @@
-import time
 import board
-import busio
 import displayio
+import terminalio
+from adafruit_display_text import label
 import adafruit_ssd1327
 
 displayio.release_displays()
 
-# This pinout works on a Metro and may need to be altered for other boards.
-spi = busio.SPI(board.SCL, board.SDA)
-tft_cs = board.D6
-tft_dc = board.D9
-tft_reset = board.D5
+# Use for I2C
+i2c = board.I2C()
+display_bus = displayio.I2CDisplay(i2c, device_address=0x3D)
 
-display_bus = displayio.FourWire(
-    spi, command=tft_dc, chip_select=tft_cs, reset=tft_reset, baudrate=1000000
+# Use for SPI
+# spi = board.SPI()
+# oled_cs = board.D5
+# oled_dc = board.D6
+# display_bus = displayio.FourWire(
+#    spi, command=oled_dc, chip_select=oled_cs, baudrate=1000000, reset=board.D9
+# )
+
+WIDTH = 128
+HEIGHT = 128
+BORDER = 8
+FONTSCALE = 1
+
+display = adafruit_ssd1327.SSD1327(display_bus, width=WIDTH, height=HEIGHT)
+
+# Make the display context
+splash = displayio.Group(max_size=10)
+display.show(splash)
+
+# Draw a background rectangle, but not the full display size
+color_bitmap = displayio.Bitmap(
+    display.width - BORDER * 2, display.height - BORDER * 2, 1
 )
-time.sleep(1)
-display = adafruit_ssd1327.SSD1327(display_bus, width=128, height=128)
+color_palette = displayio.Palette(1)
+color_palette[0] = 0xFFFFFF  # White
+bg_sprite = displayio.TileGrid(
+    color_bitmap, pixel_shader=color_palette, x=BORDER, y=BORDER
+)
+splash.append(bg_sprite)
+
+# Draw a smaller inner rectangle
+inner_bitmap = displayio.Bitmap(
+    display.width - BORDER * 4, display.height - BORDER * 4, 1
+)
+inner_palette = displayio.Palette(1)
+inner_palette[0] = 0x888888  # Gray
+inner_sprite = displayio.TileGrid(
+    inner_bitmap, pixel_shader=inner_palette, x=BORDER * 2, y=BORDER * 2
+)
+splash.append(inner_sprite)
+
+# Draw a label
+text = "Hello World!"
+text_area = label.Label(terminalio.FONT, text=text, color=0xFFFFFF)
+text_width = text_area.bounding_box[2] * FONTSCALE
+text_group = displayio.Group(
+    max_size=10,
+    scale=FONTSCALE,
+    x=display.width // 2 - text_width // 2,
+    y=display.height // 2,
+)
+text_group.append(text_area)  # Subgroup for text scaling
+splash.append(text_group)
+
+while True:
+    pass


### PR DESCRIPTION
Examples were updated to be more like the ones included in the SSD1325 library. The major change is emphasis was changed to make I2C the default initializer. This also removes a print statement from the driver.