### PR TITLE
resolves #13 Missing Type Annotations

### DIFF
--- a/adafruit_ssd1327.py
+++ b/adafruit_ssd1327.py
@@ -54,19 +54,13 @@ _INIT_SEQUENCE = (
 
 # pylint: disable=too-few-public-methods
 class SSD1327(displayio.Display):
-    r"""SSD1327 driver
+    """SSD1327 driver
 
     :param ~displayio.I2CDisplay bus: The data bus the display is on
-    :param \**kwargs:
-        See below
-
-    :Keyword Arguments:
-        * *width* (``int``) --
-          Display width
-        * *height* (``int``) --
-          Display height
-        * *rotation* (``int``) --
-          Display rotation
+    :param int height: (keyword-only) The height of the screen
+    :param int width: (keyword-only) The width of the screen
+    :param int rotation: (keyword-only) The rotation.orientation of the
+        screen, in degrees
     """
 
     def __init__(self, bus: displayio.I2CDisplay, **kwargs) -> None:

--- a/adafruit_ssd1327.py
+++ b/adafruit_ssd1327.py
@@ -54,10 +54,10 @@ _INIT_SEQUENCE = (
 # pylint: disable=too-few-public-methods
 class SSD1327(displayio.Display):
     """SSD1327 driver
-    kwargs:
-    param: height in pixels
-    param: width in pixels
-    param: optional rotation : 0 < rotation < 180 results in 90 degree rotation
+
+    :param int height: height in pixels
+    :param int width: width in pixels
+    :param int rotation: rotation in degrees 0 < rotation < 180 results in 90 degree rotation
     """
 
     def __init__(self, bus: displayio.I2CDisplay, **kwargs) -> None:

--- a/adafruit_ssd1327.py
+++ b/adafruit_ssd1327.py
@@ -53,9 +53,14 @@ _INIT_SEQUENCE = (
 
 # pylint: disable=too-few-public-methods
 class SSD1327(displayio.Display):
-    """SSD1327 driver"""
+    """SSD1327 driver
+    kwargs:
+    param: height in pixels
+    param: width in pixels
+    param: optional rotation : 0 < rotation < 180 results in 90 degree rotation
+    """
 
-    def __init__(self, bus, **kwargs):
+    def __init__(self, bus: displayio.I2CDisplay, **kwargs) -> None:
         # Patch the init sequence for 32 pixel high displays.
         init_sequence = bytearray(_INIT_SEQUENCE)
         height = kwargs["height"]

--- a/adafruit_ssd1327.py
+++ b/adafruit_ssd1327.py
@@ -54,9 +54,9 @@ _INIT_SEQUENCE = (
 
 # pylint: disable=too-few-public-methods
 class SSD1327(displayio.Display):
-    """SSD1327 driver
+    r"""SSD1327 driver
 
-    :param ~displayio.I2CDisplay bus: I2C bus
+    :param ~displayio.I2CDisplay bus: The data bus the display is on
     :param \**kwargs:
         See below
 

--- a/adafruit_ssd1327.py
+++ b/adafruit_ssd1327.py
@@ -59,7 +59,7 @@ class SSD1327(displayio.Display):
     :param ~displayio.I2CDisplay bus: The data bus the display is on
     :param int height: (keyword-only) The height of the screen
     :param int width: (keyword-only) The width of the screen
-    :param int rotation: (keyword-only) The rotation.orientation of the
+    :param int rotation: (keyword-only) The rotation/orientation of the
         screen, in degrees
     """
 

--- a/adafruit_ssd1327.py
+++ b/adafruit_ssd1327.py
@@ -51,13 +51,22 @@ _INIT_SEQUENCE = (
     b"\xAF\x00"  # DISPLAY_ON
 )
 
+
 # pylint: disable=too-few-public-methods
 class SSD1327(displayio.Display):
     """SSD1327 driver
 
-    :param int height: height in pixels
-    :param int width: width in pixels
-    :param int rotation: rotation in degrees 0 < rotation < 180 results in 90 degree rotation
+    :param ~displayio.I2CDisplay bus: I2C bus
+    :param \**kwargs:
+        See below
+
+    :Keyword Arguments:
+        * *width* (``int``) --
+          Display width
+        * *height* (``int``) --
+          Display height
+        * *rotation* (``int``) --
+          Display rotation
     """
 
     def __init__(self, bus: displayio.I2CDisplay, **kwargs) -> None:


### PR DESCRIPTION
submitted for review/comment:

I went a little further here and added the kwargs to the docstring.  Also, if rotation is triggered the action is raising questions in my mind compared to the spi devices I did prior:

        if "rotation" in kwargs and kwargs["rotation"] % 180 != 0:
            height = kwargs["width"]

This is just setting height = width.  Shouldn't it also set width = height to make a complete rotation of 90 deg?