### PR TITLE
Update to CPy 9 display modules

### DIFF
--- a/adafruit_ssd1327.py
+++ b/adafruit_ssd1327.py
@@ -26,7 +26,15 @@ Implementation Notes
 
 """
 
-import displayio
+from busdisplay import BusDisplay
+
+try:
+    from typing import Union
+
+    from fourwire import FourWire
+    from i2cdisplaybus import I2CDisplayBus
+except ImportError:
+    pass
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SSD1327.git"
@@ -52,17 +60,17 @@ _INIT_SEQUENCE = (
 )
 
 
-class SSD1327(displayio.Display):
+class SSD1327(BusDisplay):
     """SSD1327 driver
 
-    :param ~displayio.I2CDisplay bus: The data bus the display is on
+    :param bus: The data bus the display is on
     :param int height: (keyword-only) The height of the screen
     :param int width: (keyword-only) The width of the screen
     :param int rotation: (keyword-only) The rotation/orientation of the
         screen, in degrees
     """
 
-    def __init__(self, bus: displayio.I2CDisplay, **kwargs) -> None:
+    def __init__(self, bus: Union[FourWire, I2CDisplayBus], **kwargs) -> None:
         # Patch the init sequence for 32 pixel high displays.
         init_sequence = bytearray(_INIT_SEQUENCE)
         height = kwargs["height"]

--- a/examples/ssd1327_gamma.py
+++ b/examples/ssd1327_gamma.py
@@ -5,6 +5,8 @@ import time
 
 import board
 import displayio
+from fourwire import FourWire
+from i2cdisplaybus import I2CDisplayBus
 
 import adafruit_ssd1327
 
@@ -13,13 +15,13 @@ displayio.release_displays()
 # Use for I2C
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-display_bus = displayio.I2CDisplay(i2c, device_address=0x3D)
+display_bus = I2CDisplayBus(i2c, device_address=0x3D)
 
 # Use for SPI
 # spi = board.SPI()
 # oled_cs = board.D5
 # oled_dc = board.D6
-# display_bus = displayio.FourWire(
+# display_bus = FourWire(
 #    spi, command=oled_dc, chip_select=oled_cs, baudrate=1000000, reset=board.D9
 # )
 

--- a/examples/ssd1327_simpletest.py
+++ b/examples/ssd1327_simpletest.py
@@ -5,6 +5,8 @@ import board
 import displayio
 import terminalio
 from adafruit_display_text import label
+from fourwire import FourWire
+from i2cdisplaybus import I2CDisplayBus
 
 import adafruit_ssd1327
 
@@ -13,13 +15,13 @@ displayio.release_displays()
 # Use for I2C
 i2c = board.I2C()  # uses board.SCL and board.SDA
 # i2c = board.STEMMA_I2C()  # For using the built-in STEMMA QT connector on a microcontroller
-display_bus = displayio.I2CDisplay(i2c, device_address=0x3D)
+display_bus = I2CDisplayBus(i2c, device_address=0x3D)
 
 # Use for SPI
 # spi = board.SPI()
 # oled_cs = board.D5
 # oled_dc = board.D6
-# display_bus = displayio.FourWire(
+# display_bus = FourWire(
 #    spi, command=oled_dc, chip_select=oled_cs, baudrate=1000000, reset=board.D9
 # )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
+Adafruit-Blinka-Displayio


### PR DESCRIPTION
@gallaugher When this is released it should get rid of your warnings.